### PR TITLE
A bit of refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Jenkins CI
 
 [![Build Status](https://travis-ci.org/awasilyev/jenkins-container.svg?branch=master)](https://travis-ci.org/awasilyev/jenkins-container)
 
-Use this role to add a jenkins ci/cd service to your Ansible Container project. See Role Variables below for how to set the jenkins hostname, plugins, admin credentials and java opts. You can pass additional jenkins options as command for this container. Connect to the jenkins on port 8080.
+Use this role to add a jenkins CI/CD service to your Ansible Container project. See Role Variables below for how to set the jenkins hostname, plugins, admin credentials and java opts. You can pass additional jenkins options as command for this container. Connect to the jenkins on port 8080.
 
 Run the following commands to install the service:
 
@@ -12,13 +12,13 @@ Run the following commands to install the service:
 $ cd myproject
 
 # Install the service
-$ ansible-container install awasilyev.jenkins-container-role 
+$ ansible-container install awasilyev.jenkins-container
 ```
 
-Role Variables
---------------
+Envrionment Variables
+---------------------
 
-Set the following environment variables in container.yml:
+Set the following environment variables in `container.yml`:
 
 JENKINS_HOSTNAME
 > jenkins hostname (default: "localhost")
@@ -34,6 +34,34 @@ JENKINS_ADMIN_PASSWORD
 
 JENKINS_JAVA_OPTIONS
 > additional options for java (default: "-Djenkins.install.runSetupWizard=false")
+
+Role Variables
+--------------
+
+Set the following variables in `main.yml`: 
+
+jenkins_version:
+> Set the version to install, for example: 2.37 This is left undefined by default, which causes the latest version to be installed. 
+
+jenkins_hostname: localhost
+> Set the hostname.
+
+jenkins_url_prefix: ""
+> Set the value of *--prefix* in the Jenkins initialization java invocation, creating an access path like *http://www.example.com{{ jenkins_url_prefix }}*. Be sure to start the prefix with a '/' (i.e. */jenkins*).
+
+jenkins_http_port: 8080
+> Port for accessing the Jenkins web interface.
+
+jenkins_connection_delay: 5
+jenkins_connection_retries: 60
+> Set the number of tries, and the amount of time between each try, while attempting to connect to Jenkins after initial startup. Total time spent waiting on equals retries * delay, or if using the default values, 300 seconds.
+
+jenkins_home: /var/lib/jenkins
+> Set the path where artifacts, workspace, and plugins will be stored.
+
+jenkins_jar_location: /opt/jenkins-cli.jar
+> Path where *jenkins-cli.jar* will be kept.
+
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-Jenkins CI
-=========
-
 [![Build Status](https://travis-ci.org/awasilyev/jenkins-container.svg?branch=master)](https://travis-ci.org/awasilyev/jenkins-container)
 
-Use this role to add a jenkins CI/CD service to your Ansible Container project. See Role Variables below for how to set the jenkins hostname, plugins, admin credentials and java opts. You can pass additional jenkins options as command for this container. Connect to the jenkins on port 8080.
+# Jenkins CI
 
-Run the following commands to install the service:
+Use this role to add a jenkins CI/CD service to your Ansible Container project.
+
+Run the following to install the service:
 
 ```
 # Set the working directory to your Ansible Container project root
@@ -15,66 +14,56 @@ $ cd myproject
 $ ansible-container install awasilyev.jenkins-container
 ```
 
-Envrionment Variables
----------------------
+## Post Installation
 
-Set the following environment variables in `container.yml`:
+### Connecting 
 
-JENKINS_HOSTNAME
-> jenkins hostname (default: "localhost")
+In `container.yml` the Jenkins server port is mapped to host port **8080**. If you're using Docker Engine or Docker for Mac to run the service, connect to the web console at [http://localhost:8080](http://localhost:8080).
 
-JENKINS_PLUGINS
-> comma-separated list of plugins (default: "")
+### Persisting data
 
-JENKINS_ADMIN_USERNAME
-> username for jenkins admin user (default "admin")
+Jenkins data, plugins, artifacts, etc. are written to */var/lib/jenkins*. During container runtime, if you want to persist this data, add a *volume* directive to `container.yml` that maps a host path or named volume to this path. 
 
-JENKINS_ADMIN_PASSWORD
-> password for jenkins admin user (default "admin")
+### Configuring
 
-JENKINS_JAVA_OPTIONS
-> additional options for java (default: "-Djenkins.install.runSetupWizard=false")
+On startup the *jenkins* container executes */usr/bin/startup_jenkins.sh* to install plugins, and launch the Jenkins process. Any parameters passed to this script via the *command* directive in `container.yml` will be appended to the `java` command used to launch Jenkins. View [start_jenkins.sh.j2](./templates/start_jenkins.sh.j2) for a look at the template used to create this script during image build.
 
-Role Variables
---------------
+See Environment Variables, and Role Variables below for details on setting the admin credentials, installing plugins, passing additional Java options, and determining the Jenkins version to install. 
 
-Set the following variables in `main.yml`: 
+## Environment Variables
 
-jenkins_version:
-> Set the version to install, for example: 2.37 This is left undefined by default, which causes the latest version to be installed. 
+The following variables are defined in `container.yml`, and set as environment variables in the *jenkins* container:
 
-jenkins_hostname: localhost
-> Set the hostname.
+JENKINS_ADMIN_USERNAME: admin
+> Set the username for jenkins admin user.
 
-jenkins_url_prefix: ""
-> Set the value of *--prefix* in the Jenkins initialization java invocation, creating an access path like *http://www.example.com{{ jenkins_url_prefix }}*. Be sure to start the prefix with a '/' (i.e. */jenkins*).
+JENKINS_ADMIN_PASSWORD: admin
+> Set the password for jenkins admin user.
 
-jenkins_http_port: 8080
-> Port for accessing the Jenkins web interface.
+JENKINS_JAVA_OPTIONS: ""
+> Provide additional options to the `java` command used to launch Jenkins in the container startup script, */start_jenkins.sh*.
 
-jenkins_connection_delay: 5
-jenkins_connection_retries: 60
-> Set the number of tries, and the amount of time between each try, while attempting to connect to Jenkins after initial startup. Total time spent waiting on equals retries * delay, or if using the default values, 300 seconds.
-
-jenkins_home: /var/lib/jenkins
-> Set the path where artifacts, workspace, and plugins will be stored.
-
-jenkins_jar_location: /opt/jenkins-cli.jar
-> Path where *jenkins-cli.jar* will be kept.
+JENKINS_PLUGINS: ""
+> Provide a comma-separated list of plugins.
 
 
-Dependencies
-------------
+## Role Variables
+
+jenkins_version: latest 
+> Set to a specific version of Jenkins to install during image build, or 'latest' to install the latest version. 
+
+jenkins_dependencies: []
+> List of packages to be installed during image build. The list in [defaults/main.yml](./defaults/main.yml), will be added to the project `main.yml` when the role installed. Add any additional packages that may be required by any plugins you plan to install. For example, if you plan to install the *git* plugin, it depends on the *git* package being installed.
+
+## Dependencies
 
 None.
 
-License
--------
+## License
 
 MIT/BSD
 
-Author Information
-------------------
+## Author Information
 
 [@awasilyev](https://github.com/awasilyev)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ In `container.yml` the Jenkins server port is mapped to host port **8080**. If y
 
 ### Persisting data
 
-Jenkins data, plugins, artifacts, etc. are written to */var/lib/jenkins*. During container runtime, if you want to persist this data, add a *volume* directive to `container.yml` that maps a host path or named volume to this path. 
+Jenkins data, plugins, artifacts, etc. are written to */var/lib/jenkins*. During container runtime, if you want to persist this data between container runs, add a *volume* directive to `container.yml` that maps a host path or named volume to this path. 
+
+During the build process */var/lib/jenkins* is destroyed and recreated, thus clearing any existing Jenkins data. This is done so that if the service is deployed to a cluster, such as OpenShift, where the service is not gauranteed to run as user *jenkins*, there won't be any secret or key files left over from the build process that are exclusively read-only by the *jenkins* user. So for obvious reasons, do not mount a volume to this path during the image build.
 
 ### Configuring
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,8 @@
-# it will use latest jenkins if this is undefined
-#jenkins_version: 2.37
-
-jenkins_hostname: localhost
-jenkins_url_prefix: ""
-jenkins_http_port: 8080
-jenkins_connection_delay: 5
-jenkins_connection_retries: 60
-jenkins_home: /var/lib/jenkins
-jenkins_jar_location: /opt/jenkins-cli.jar
+jenkins_version: latest
+jenkins_dependencies:
+  - curl
+  - libselinux-python
+  - java-1.8.0-openjdk-headless
+  - dejavu-sans-fonts
+  - fontconfig
+  - psmisc

--- a/meta/container.yml
+++ b/meta/container.yml
@@ -1,13 +1,18 @@
 jenkins:
   image: centos:7
-  entrypoint: ['/entrypoint.sh']
+  entrypoint: ['/usr/bin/entrypoint.sh']
+  command: ['/usr/bin/dumb-init', '/usr/bin/start_jenkins.sh']
   working_dir: /
   user: jenkins
   environment:
-    JENKINS_HOSTNAME: '{{ JENKINS_HOSTNAME | default("localhost") }}' 
-    JENKINS_ADMIN_USERNAME: '{{ JENKINS_ADMIN_USERNAME | default("admin") }}'
-    JENKINS_ADMIN_PASSWORD: '{{ JENKINS_ADMIN_PASSWORD | default("admin") }}'
-    JENKINS_JAVA_OPTIONS: '{{ JENKINS_JAVA_OPTIONS }}'
-    JENKINS_PLUGINS: '{{ JENKINS_PLUGINS }}'
+    JENKINS_ADMIN_USERNAME: admin
+    JENKINS_ADMIN_PASSWORD: admin
+    JENKINS_JAVA_OPTIONS: ''
+    JENKINS_PLUGINS: ''
   ports:
-    - 8080:8080
+  - 8080:8080
+
+  # Optionally persist Jenkins data, artifacts, plugins, etc.
+  #dev_overrides:
+  #  volumes:
+  #   - <host-path>:/var/lib/jenkins

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 # Setup/install tasks.
 - include: setup.yml
 
-- name: Add entrypoint script
+- name: Add entrypoint scripts
   template:
    src: "{{ item }}.j2"
    dest: "/usr/bin/{{ item }}"
@@ -12,14 +12,6 @@
   with_items:
    - entrypoint.sh
    - start_jenkins.sh
-
-- name: Create custom init scripts directory.
-  file:
-    path: "{{ jenkins_home }}/init.groovy.d"
-    state: directory
-    owner: jenkins
-    group: jenkins
-    mode: 0775
 
 # Make sure Jenkins starts, then configure Jenkins.
 - name: Start jenkins
@@ -46,15 +38,30 @@
 - name: Stop jenkins
   shell: killall -15 java
 
-- name: Fix directory ownership
-  shell: chown -R jenkins:root {{ item }}
+- name: Remove jenkins directories 
+  file:
+    path: "{{ item }}" 
+    state: absent
   with_items:
-    - /var/lib/jenkins
+    - "{{ jenkins_home }}"
     - /var/cache/jenkins
 
-- name: Fix directory permissions 
-  shell: chmod 775 {{ item }}
+- name: Recreate jenkins directories with correct ownership 
+  file:
+    path: "{{ item }}"
+    owner: jenkins
+    group: root
+    mode: 0775
+    state: directory
   with_items:
-    - /var/lib/jenkins
+    - "{{ jenkins_home }}"
     - /var/cache/jenkins
+
+- name: Create custom init scripts directory.
+  file:
+    path: "{{ jenkins_home }}/init.groovy.d"
+    state: directory
+    owner: jenkins
+    group: root 
+    mode: 0775
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,10 +43,18 @@
   retries: 5
   delay: 10
 
-# Fix owner
-- name: Fix owner
-  shell: chown -R jenkins /var/lib/jenkins
-
-# Stop jenkins
 - name: Stop jenkins
   shell: killall -15 java
+
+- name: Fix directory ownership
+  shell: chown -R jenkins:root {{ item }}
+  with_items:
+    - /var/lib/jenkins
+    - /var/cache/jenkins
+
+- name: Fix directory permissions 
+  shell: chmod 775 {{ item }}
+  with_items:
+    - /var/lib/jenkins
+    - /var/cache/jenkins
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Add entrypoint script
   template:
    src: "{{ item }}.j2"
-   dest: "/{{ item }}"
+   dest: "/usr/bin/{{ item }}"
    owner: root
    group: root
    mode: 0775
@@ -23,7 +23,7 @@
 
 # Make sure Jenkins starts, then configure Jenkins.
 - name: Start jenkins
-  shell: bash -c "/start_jenkins.sh &"
+  shell: bash -c "/usr/bin/start_jenkins.sh &"
   become_user: jenkins
 
 - name: Wait for Jenkins to start up before proceeding.

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -1,14 +1,9 @@
 ---
 - name: Ensure dependencies are installed.
   package:
-    name: 
-      - curl
-      - libselinux-python
-      - java-1.8.0-openjdk-headless
-      - dejavu-sans-fonts
-      - fontconfig
-      - psmisc
+    name: "{{ item }}"
     state: installed
+  with_items: "{{ jenkins_dependencies }}"
 
 - name: Ensure Jenkins repo is installed.
   get_url:
@@ -24,7 +19,7 @@
   get_url:
     url: "{{ jenkins_pkg_url }}/jenkins-{{ jenkins_version }}-1.1.noarch.rpm"
     dest: "/tmp/jenkins.rpm"
-  when: jenkins_version is defined
+  when: jenkins_version != 'latest'
 
 - name: Check if we downloaded a specific version of Jenkins.
   stat:
@@ -47,4 +42,19 @@
   package:
     name: jenkins
     state: installed
-  when: jenkins_version is undefined
+  when: jenkins_version == 'latest' 
+
+- name: Update jenkins user
+  user:
+    name: jenkins
+    uid: 1000
+    groups: root
+    append: yes
+
+- name: Install dumb init
+  get_url:
+    url: https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64
+    dest: /usr/bin/dumb-init
+    owner: root
+    group: root
+    mode: 0775

--- a/templates/entrypoint.sh.j2
+++ b/templates/entrypoint.sh.j2
@@ -22,4 +22,4 @@ if (!instance.isUseSecurity()) {
 }
 EOT
 
-exec /start_jenkins.sh "$@"
+exec "$@"

--- a/templates/start_jenkins.sh.j2
+++ b/templates/start_jenkins.sh.j2
@@ -1,7 +1,12 @@
 #!/bin/bash
 set -m
 
-exec java -DJENKINS_HOME={{ jenkins_home }} -Djenkins.install.runSetupWizard=false -Djava.awt.headless=true -jar /usr/lib/jenkins/jenkins.war ${JENKINS_JAVA_OPTIONS} --httpPort={{ jenkins_http_port }} --webroot=/var/cache/jenkins/war  "$@" &
+exec java -DJENKINS_HOME={{ jenkins_home }} \
+    -Djenkins.install.runSetupWizard=false \
+    -Djava.awt.headless=true \
+    -jar /usr/lib/jenkins/jenkins.war ${JENKINS_JAVA_OPTIONS} \
+    --httpPort={{ jenkins_http_port }} \
+    --webroot=/var/cache/jenkins/war  "$@" &
 
 while ! timeout 1 bash -c "echo > /dev/tcp/localhost/{{ jenkins_http_port }}"; do echo waiting; sleep 10; done
 
@@ -9,14 +14,21 @@ mkdir -p {{ jenkins_home }}
 curl -L https://updates.jenkins-ci.org/update-center.json | sed '1d;$d' > "{{ jenkins_home }}/updates/default.json"
 
 if [ "${JENKINS_PLUGINS}" == "" ]; then
-  fg
+    fg
 else 
-  IFS=","
-  for p in ${JENKINS_PLUGINS}; do
-   echo adding $p
-   java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix | default('') }}/ install-plugin $p --username $JENKINS_ADMIN_USERNAME --password $JENKINS_ADMIN_PASSWORD 
-   echo done
-  done
-  java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix | default('') }}/ safe-restart --username $JENKINS_ADMIN_USERNAME --password $JENKINS_ADMIN_PASSWORD 
-  fg
+    IFS=","
+    for p in ${JENKINS_PLUGINS}; do
+       echo adding $p
+       java \
+          -jar {{ jenkins_jar_location }} \
+          -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix | default('') }}/ \
+          install-plugin $p \
+          --username $JENKINS_ADMIN_USERNAME \
+          --password $JENKINS_ADMIN_PASSWORD 
+       echo done
+    done
+    java -jar {{ jenkins_jar_location }} \
+         -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix | default('') }}/ \
+         safe-restart --username ${JENKINS_ADMIN_USERNAME} --password ${JENKINS_ADMIN_PASSWORD}
+    fg
 fi

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,5 +3,10 @@ jenkins_repo_url: http://pkg.jenkins.io/redhat/jenkins.repo
 jenkins_repo_key_url: http://pkg.jenkins.io/redhat/jenkins.io.key
 jenkins_pkg_url: http://pkg.jenkins.io/redhat
 jenkins_java_options_env_var: JENKINS_JAVA_OPTIONS
-
+jenkins_hostname: localhost
+jenkins_url_prefix: ""
+jenkins_http_port: 8080
 jenkins_home: /var/lib/jenkins
+jenkins_jar_location: /opt/jenkins-cli.jar
+jenkins_connection_delay: 3
+jenkins_connection_retries: 40


### PR DESCRIPTION
- Simplifies role variables, only surfacing the items that are actually important
- One of the role variables is the list of packages, allowing the user to add packages at build time that may be required by a plugin
- Refactors the README, adding a Post Installation section 
- Removes anything left behind in /var/lib/jenkins after the start/stop of the jenkins process. This insures that nothing is exclusively read-only by the *jenkins* user. Without this, the image cannot be deployed to OpenShift
- Added dumb-init, because that's a best practice. You'll notice with it, a ctrl-c to stop the container works instantly. Without it, it takes several seconds to stop the container
- And probably other bits that escape my memory at this point... 

I tested deploying to OpenShift, and it works! That's really cool, and after we merge this, I want to do screencast of the deployment. 

I also tested installing plugin, which is also very cool. I tested by installing the *git* package, and the *git* plugin.
